### PR TITLE
Add: email and password validators with separate error file

### DIFF
--- a/src/error/error.js
+++ b/src/error/error.js
@@ -1,0 +1,7 @@
+module.exports = {
+    NoSpace: 'No space allowed in password',
+    NotSame: "Password must be same",
+    AtLeast8: 'Password must be atleast 8 characters',
+    MustChar: 'Password must contain one uppercase, lowercas, digit and special character',
+    InvalidEmail: 'Email is not valid'
+}

--- a/src/utils/EmailValidation.js
+++ b/src/utils/EmailValidation.js
@@ -1,0 +1,13 @@
+const errors = require('../error/error')
+
+const emailValidator = (req, res, next) => {
+    const { email } = req.body
+    const emailValidatorRegex = RegExp(/^[a-zA-Z0-9._-]+@([a-z]+\.)?nits\.ac\.in$/)
+
+    if (!emailValidatorRegex.test(email)) {
+        res.status(400).json({ error: errors.InvalidEmail });
+    }
+    else next();
+}
+
+module.exports = emailValidator

--- a/src/utils/PasswordValidation.js
+++ b/src/utils/PasswordValidation.js
@@ -1,1 +1,25 @@
-// pwd validation logic goes here
+const errors = require('../error/error')
+
+const passwordValidator = (req, res, next) => {
+    const { password, confirmPassword } = req.body;
+    const lowerCase = /[a-z]/.test(password),
+          upperCase = /[A-Z]/.test(password),
+          numbers = /\d/.test(password),
+          specialChar = /[`!@#$%^&*()_+=|:;<>,./?"'{}]/.test(password);
+
+    if (/\s/.test(password)||/\s/.test(confirmPassword)) {
+        res.status(400).json({ error: errors.NoSpace });
+    }
+    else if(password !== confirmPassword) {
+        res.status(400).json({ error: errors.NotSame });
+    }
+    else if(password.length < 8) {
+        res.status(400).json({ error: errors.AtLeast8 });
+    }
+    else if(!(lowerCase && upperCase && numbers && specialChar)) {
+        res.status(400).json({ error: errors.MustChar });
+    }
+    else next();
+}
+
+module.exports = passwordValidator


### PR DESCRIPTION
email validator validates email id's of format <name>@<branch>.nits.ac.in or <name>@nits.ac.in
password validator allows password that matches with confirm password and has no space, minimum length of 8, contains at least 1 uppercase, 1 lowercase, 1 digit and a special character.

closes #3 